### PR TITLE
Fix issue: 'Invalid prop `isOpen` of type `boolean` 

### DIFF
--- a/src/components/Configurator/Configurator.js
+++ b/src/components/Configurator/Configurator.js
@@ -231,7 +231,7 @@ export default function Configurator(props) {
 }
 Configurator.propTypes = {
   secondary: PropTypes.bool,
-  isOpen: PropTypes.func,
+  isOpen: PropTypes.bool,
   onClose: PropTypes.func,
   fixed: PropTypes.bool,
 };


### PR DESCRIPTION
Fix browser console warning: "Warning: Failed prop type: Invalid prop `isOpen` of type `boolean` supplied to `Configurator`, expected `function`."