### PR TITLE
Fix browser warning: Invalid DOM property `fontsize`.

### DIFF
--- a/src/components/Navbars/AuthNavbar.js
+++ b/src/components/Navbars/AuthNavbar.js
@@ -80,7 +80,7 @@ export default function AuthNavbar(props) {
       color={mainText}
     >
       <CreativeTimLogo w="32px" h="32px" me="10px" />
-      <Text fontsize="sm" mt="3px">
+      <Text fontSize="sm" mt="3px">
         {logoText}
       </Text>
     </Link>


### PR DESCRIPTION
Fix browser warning: "Warning: Invalid DOM property `fontsize`. Did you mean `fontSize`?"