### PR TITLE
Fix invalid html attribute 'colorScheme' browser error in Hamburger

### DIFF
--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -468,7 +468,6 @@ export function SidebarResponsive(props) {
         w="18px"
         h="18px"
         ref={btnRef}
-        colorScheme="teal"
         onClick={onOpen}
       />
       <Drawer


### PR DESCRIPTION
Fix invalid html attribute 'colorScheme' browser error in Hamburger icon:

Warning: React does not recognize the `colorScheme` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `colorscheme` instead. If you accidentally passed it from a parent component, remove it from the DOM element.