### PR TITLE
Fix browser error: "Warning: Function components cannot be given refs…"

### DIFF
--- a/src/layouts/Admin.js
+++ b/src/layouts/Admin.js
@@ -20,8 +20,6 @@ export default function Dashboard(props) {
   // states and functions
   const [sidebarVariant, setSidebarVariant] = useState("transparent");
   const [fixed, setFixed] = useState(false);
-  // ref for main panel div
-  const mainPanel = React.createRef();
   // functions for changing the states from components
   const getRoute = () => {
     return window.location.pathname !== "/admin/full-screen-maps";
@@ -104,7 +102,6 @@ export default function Dashboard(props) {
         {...rest}
       />
       <MainPanel
-        ref={mainPanel}
         w={{
           base: "100%",
           xl: "calc(100% - 275px)",

--- a/src/layouts/RTL.js
+++ b/src/layouts/RTL.js
@@ -21,8 +21,6 @@ export default function Dashboard(props) {
   // states and functions
   const [sidebarVariant, setSidebarVariant] = useState("transparent");
   const [fixed, setFixed] = useState(false);
-  // ref for main panel div
-  const mainPanel = React.createRef();
   const getRoute = () => {
     return window.location.pathname !== "/admin/full-screen-maps";
   };
@@ -106,7 +104,6 @@ export default function Dashboard(props) {
         />
         <MainPanel
           variant="rtl"
-          ref={mainPanel}
           w={{
             base: "100%",
             xl: "calc(100% - 275px)",


### PR DESCRIPTION
Fixes browser error: "Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?"

Refs forwarded to components appeared to be unused, so I removed them.