### PR TITLE
fix: framer-motion downgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@fontsource/roboto": "^4.5.0",
     "apexcharts": "^3.27.3",
     "classnames": "2.3.1",
-    "framer-motion": "^4.1.17",
+    "framer-motion": "3.10.6",
     "match-sorter": "6.3.0",
     "moment": "2.29.1",
     "node-sass": "7.0.1",


### PR DESCRIPTION
framer-motion: ^4.1.17 produces following error:

> Uncaught TypeError: framer_motion__WEBPACK_IMPORTED_MODULE_5__.motion.custom is not a function

Due to the following warning

> Because motion.custom() is deprecated. Use motion() instead.

To fix this, framer-motion is downgraded to 3.10.6.

This issue comes from chakra-ui (checkbox component and some other components maybe). As stated in chakra-ui issues; framer-motion 4 breaks the code, using 3.10.6 works properly.